### PR TITLE
Leap year rule change

### DIFF
--- a/src/calendrical.calendar.base.js
+++ b/src/calendrical.calendar.base.js
@@ -241,7 +241,9 @@ var Calendrical = (function(exports){
 
   // Update the Bahai data representation
   calendar.updateBahai = function(jd) {
-    var bahcal = this.jdToBahai(jd);
+    var bahcal = this.jdToBahai(jd),
+        bahYear = ((((bahcal[0] - 1) * 19) + bahcal[1] - 1) * 19) +
+                    bahcal[2] - 1;
 
     data.bahai = {
       kull_i_shay : bahcal[0],
@@ -249,11 +251,10 @@ var Calendrical = (function(exports){
       year        : this.constants.bahai.YEARS[bahcal[2] - 1],
       month       : this.constants.bahai.MONTHS[bahcal[3] - 1],
       day         : this.constants.bahai.DAYS[bahcal[4] - 1],
-      weekday     : this.constants.bahai.WEEKDAYS[astro.jwday(jd)]
+      weekday     : this.constants.bahai.WEEKDAYS[astro.jwday(jd)],
+      leap        : this.leapBahai(bahYear),
+      official    : bahYear < 223
     }
-
-    // Bahai uses same leap rule as Gregorian
-    data.bahai.leap = this.leapGregorian(this.jdToGregorianYear(jd));
 
     return data.bahai;
   }

--- a/src/calendrical.calendar.constants.js
+++ b/src/calendrical.calendar.constants.js
@@ -59,6 +59,7 @@ var Calendrical = (function(exports){
 
     bahai: {
       EPOCH: 2394646.5,
+      EPOCH172: 2457102.5,
       WEEKDAYS: ["Jamál", "Kamál", "Fidál", "Idál", "Istijlál", "Istiqlál", "Jalál"],
       YEARS: ["Alif", "Bá", "Ab", "Dál", "Báb", "Váv", "Abad", "Jád", "Bahá", "Hubb", "Bahháj", "Javáb", "Ahad", "Vahháb", "Vidád", "Badí", "Bahí", "Abhá", "Vahíd"],
       MONTHS: ["Bahá", "Jalál", "Jamál", "`Azamat", "Núr", "Rahmat", "Kalimát", "Kamál", "Asmá", "`Izzat", "Mashíyyat", "`Ilm", "Qudrat", "Qawl", "Masáil", "Sharaf", "Sultán", "Mulk", "Ayyám-i-Há", "`Alá'"],


### PR DESCRIPTION
Starting from the year 172 Bahai Era - this corresponds to 2015-03-20 in the Gregorian calendar - the leap year rule is not aligned with the Gregorian calendar.  Instead it is strictly observing the astronomical event of the Vernal Equinox.  If the time-span between two adjacent Vernal Equinoxes is longer than 365 days, the year is a leap year.  The Bahai World Centre has officially communicated the beginnings of the years 172 to 221 Bahai Era.  This code change calculates the start of each year, it claims to be accurate for years beyond 221.  This is why the Bahai calendar has an extra attribute denoting its officiality to the Bahai World Centre's data provided.
For consistency, the Bahai cycle was renamed to vahid.
