### PR TITLE
Add tibetan month leap logic

### DIFF
--- a/src/calendrical.calendar.conversions.js
+++ b/src/calendrical.calendar.conversions.js
@@ -971,23 +971,17 @@ var Calendrical = (function (exports) {
       years = Math.ceil ((jd - this.constants.tibetan.EPOCH) / capY);
 
       year0 = astro.final (years, function (y0) {
-          var j0 = calendar.tibetanToJd ([ y0, 1, false, 1, false ]);
-
-          return jd >= j0;
+          return jd >= calendar.tibetanToJd ([ y0, 1, false, 1, false ]);
       });
 
       month0 = astro.final (1, function (m0) {
-          var j0 = calendar.tibetanToJd ([ year0, m0, false, 1, false ]);
-
-          return jd >= j0;
+          return jd >= calendar.tibetanToJd ([ year0, m0, false, 1, false ]);
       });
 
       est = jd - this.tibetanToJd ([ year0, month0, false, 1, false ]);
 
       day0 = astro.final (est - 2, function (d0) {
-          var j0 = calendar.tibetanToJd ([ year0, month0, false, d0, false ]);
-
-          return jd >= j0;
+          return jd >= calendar.tibetanToJd ([ year0, month0, false, d0, false ]);
       });
 
       monthLeap = day0 > 30;
@@ -1014,6 +1008,11 @@ var Calendrical = (function (exports) {
       dayLeap = jd === this.tibetanToJd ([ year, month, monthLeap, day, true ]);
 
       return [ year, month, monthLeap, day, dayLeap ];
+  };
+
+  calendar.tibetanMonthLeap = function (year, month) {
+      return month ===
+              this.jdToTibetan (this.tibetanToJd ([ year, month, true, 2, false ]))[1];
   };
 
   return exports;

--- a/test/spec/calendar.tibetan.spec.js
+++ b/test/spec/calendar.tibetan.spec.js
@@ -28,18 +28,12 @@ describe ("Tibetan calendar spec", function () {
   });
 
   it ("should establish whether a Tibetan month is leap", function () {
-      [ 2933, 3570, 3795, 4197, 4340, 4389,
-        4492, 4536, 4593, 4660, 4869, 4940
-      ].forEach (function (year) {
-          actual   = cal.leapHinduLunarOld (year);
-          expect (true).toEqual (actual);
-      });
+      data4.forEach (function (data) {
+          date     = data.tibetan;
+          expected = date.leapMonth;
+          actual   = cal.tibetanMonthLeap (date.year, date.month);
 
-      [ 2515, 3171, 3236, 3677, 4114, 4291, 4399, 4654, 4749, 4781,
-        4817, 4920, 5004, 5030, 5042, 5044, 5092, 5096, 5139, 5195
-      ].forEach (function (year) {
-          actual   = cal.leapHinduLunarOld (year);
-          expect (false).toEqual (actual);
+          expect (expected).toEqual (actual);
       });
   });
 });


### PR DESCRIPTION
Simplified logic in jdToTibetan.
The extra variable was there for debugging purposes.

Implemented the leap month logic and provided a test specification.