### PR TITLE
There is a mix-up between persian Astronomic and Arithmetic leap rule

### DIFF
--- a/src/calendrical.calendar.conversions.js
+++ b/src/calendrical.calendar.conversions.js
@@ -551,15 +551,18 @@ var Calendrical = (function (exports) {
 
   // Is a given year a leap year in the Persian
   // astronomical calendar?
-  calendar.leapPersiana = function(year) {
-    return (this.persianaToJd(year + 1, 1, 1) -
-      this.persianaToJd(year, 1, 1)) > 365;
-  }
+  calendar.leapPersian = function (year) {
+    return this.persianaToJd (year + 1, 1, 1) -
+      this.persianaToJd (year, 1, 1) > 365;
+  };
 
-  // Is a given year a leap year in the Persian calendar?
-  calendar.leapPersian = function(year) {
-    return ((((((year - ((year > 0) ? 474 : 473)) % 2820) + 474) + 38) * 682) % 2816) < 682;
-  }
+  // Is a given year a leap year in the Persian arithmetic alendar?
+  calendar.leapPersianArithmetic = function (year) {
+      var y0 = year > 0 ? year - 474 : year - 473,
+          y1 = astro.mod (y0, 2820) + 474;
+
+      return astro.mod ((y1 + 38) * 31, 128) < 31;
+  };
 
   // Return  Universal time of midday on fixed date, date, in Tehran
   calendar.midDayInTehran = function (date) {
@@ -573,7 +576,7 @@ var Calendrical = (function (exports) {
       var approx = astro.estimatePriorSolarLongitude (this.constants.SPRING, this.midDayInTehran (date));
 
       return astro.next (Math.floor (approx) - 1, function (day) {
-          return astro.solarLongitude (calendar.midDayInTehran (day)) <= (calendar.constants.SPRING + 2);
+          return astro.solarLongitude (calendar.midDayInTehran (day)) <= calendar.constants.SPRING + 2;
       });
   };
 
@@ -586,7 +589,8 @@ var Calendrical = (function (exports) {
         Math.floor (this.constants.MEAN_TROPICAL_YEAR * temp));
 
     return nowRuz - 1 + day +
-            ((month <= 7) ? 31 * (month - 1) : 30 * (month - 1) + 6);
+            ((month <= 7) ? 31 * (month - 1) : 30 * (month - 1) + 6) +
+            this.constants.J0000;
   };
 
   // Calculate Persian date from Julian day

--- a/test/spec/calendar.persianAstronomical.spec.js
+++ b/test/spec/calendar.persianAstronomical.spec.js
@@ -11,8 +11,7 @@ describe ("Persian astronomical calendar spec", function () {
   it ("should convert a Persian astronomical date to Julian day", function () {
     data3.forEach (function (data) {
         date     = data.persianAstro;
-        // expected = data.rataDie + cal.constants.J0000;
-        expected = data.rataDie;
+        expected = data.rataDie + cal.constants.J0000;
         actual   = cal.persianToJd (date.year, date.month, date.day);
         expect (expected).toEqual (actual);
     });
@@ -22,18 +21,17 @@ describe ("Persian astronomical calendar spec", function () {
     data3.forEach (function (data) {
         date     = data.persianAstro;
         expected = [ date.year, date.month, date.day ];
-        // actual   = cal.jdToPersian (data.rataDie + cal.constants.J0000);
-        actual   = cal.jdToPersian (data.rataDie);
+        actual   = cal.jdToPersian (data.rataDie + cal.constants.J0000);
         expect (expected).toEqual (actual);
     });
   });
 
   it ("should determine whether a Persian astronomical year is leap year", function () {
-      [ 4 ].forEach (function (year) {
+      [ 324, 328, 333, 337, 341, 345, 721, 729, 770, 993, 997, 1339, 1533 ].forEach (function (year) {
           expect (cal.leapPersian (year)).toBe (true);
       });
 
-      [ 1, 2, 3 ].forEach (function (year) {
+      [ 352, 406, 408, 509, 540, 701, 709, 726, 866, 1004, 1213, 1417 ].forEach (function (year) {
           expect (cal.leapPersian (year)).toBe (false);
       });
   });


### PR DESCRIPTION
Calendrical Calculations only provides the arithmetic rule.

This PR leaves the naming to refer to persian as "astronomical persian", and only adds arithmetic when the other variant is meant.