### PR TITLE
Hindu spec split up

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -33,7 +33,8 @@
     <script src="spec/calendar.french.spec.js"></script>
     <script src="spec/calendar.hebrew.spec.js"></script>
     <script src="spec/calendar.islamic.spec.js"></script>
-    <script src="spec/calendar.hindu.spec.js"></script>
+    <script src="spec/calendar.hindu.lunar.old.spec.js"></script>
+    <script src="spec/calendar.hindu.solar.old.spec.js"></script>
     <script src="spec/calendar.tibetan.spec.js"></script>
     <script src="spec/calendar.persian.astronomical.spec.js"></script>
     <script src="spec/calendar.persian.arithmetic.spec.js"></script>

--- a/test/spec/calendar.hindu.lunar.old.spec.js
+++ b/test/spec/calendar.hindu.lunar.old.spec.js
@@ -3,30 +3,10 @@
 
 'use strict';
 
-describe ("Hindu calendar spec", function () {
+describe ("Hindu Lunar Old calendar spec", function () {
   var cal, date, expected, actual;
 
   cal = Calendrical.calendar;
-
-  it ("should convert a Hindu Solar Old date to Julian day", function () {
-    data4.forEach (function (data) {
-        date     = data.hinduSolarOld;
-        expected = data.rataDie + cal.constants.J0000;
-        actual   = cal.hinduSolarOldToJd ([ date.year, date.month, date.day ]);
-
-        expect (expected).toEqual (actual);
-    });
-  });
-
-  it ("should convert a Julian day to a Hindu Solar Old date", function () {
-    data4.forEach (function (data) {
-        date     = data.hinduSolarOld;
-        expected = [ date.year, date.month, date.day ];
-        actual   = cal.jdToHinduSolarOld (data.rataDie + cal.constants.J0000);
-
-        expect (expected).toEqual (actual);
-    });
-  });
 
   it ("should convert a Hindu Lunar Old date to Julian day", function () {
     data4.forEach (function (data) {

--- a/test/spec/calendar.hindu.solar.old.spec.js
+++ b/test/spec/calendar.hindu.solar.old.spec.js
@@ -1,0 +1,31 @@
+/* global Calendrical data4 describe it expect:true*/
+/* eslint no-undef: "error"*/
+
+'use strict';
+
+describe ("Hindu Solar Old calendar spec", function () {
+  var cal, date, expected, actual;
+
+  cal = Calendrical.calendar;
+
+  it ("should convert a Hindu Solar Old date to Julian day", function () {
+    data4.forEach (function (data) {
+        date     = data.hinduSolarOld;
+        expected = data.rataDie + cal.constants.J0000;
+        actual   = cal.hinduSolarOldToJd ([ date.year, date.month, date.day ]);
+
+        expect (expected).toEqual (actual);
+    });
+  });
+
+  it ("should convert a Julian day to a Hindu Solar Old date", function () {
+    data4.forEach (function (data) {
+        date     = data.hinduSolarOld;
+        expected = [ date.year, date.month, date.day ];
+        actual   = cal.jdToHinduSolarOld (data.rataDie + cal.constants.J0000);
+
+        expect (expected).toEqual (actual);
+    });
+  });
+
+});


### PR DESCRIPTION
The Hindu spec contains both the Solar Old and Lunar Old calendar specs.
A split makes sense here.
This PR implements it.
